### PR TITLE
Incorrect dlib Version in the requirements.txt File

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,4 +41,4 @@ torch_ema==0.3
 warmup_scheduler==0.3
 yacs==0.1.8
 numpy==1.24.4
-dlib==19.24.99
+dlib==19.24.6


### PR DESCRIPTION
The latest version of `dlib` is `19.24.6` not `19.24.99` so it needs to be changed to `19.24.6`.
![incorrect_dlib_version](https://github.com/user-attachments/assets/98aea4b0-2bba-4677-9fa3-1cda67ed11a7)
